### PR TITLE
Release thrift 0.23.0 tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/iotdb-tools-thrift-artifacts.yml
+++ b/.github/workflows/iotdb-tools-thrift-artifacts.yml
@@ -43,11 +43,11 @@ jobs:
       matrix:
         include:
           - classifier: linux-x86_64
-            runner: ubuntu-24.04
+            runner: ubuntu-22.04
             platform: linux
             maven: ./mvnw
           - classifier: linux-aarch64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             platform: linux
             maven: ./mvnw
           - classifier: mac-x86_64
@@ -160,7 +160,7 @@ jobs:
 
   bundle:
     name: Bundle all platform artifacts
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Download platform artifacts

--- a/.github/workflows/iotdb-tools-thrift-artifacts.yml
+++ b/.github/workflows/iotdb-tools-thrift-artifacts.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: maven
 
       - name: Install Linux build prerequisites
@@ -142,7 +142,7 @@ jobs:
             $archive.Dispose()
           }
 
-          $expectedBinary = if ($classifier.StartsWith("windows")) { "bin/thrift.exe" } else { "bin/thrift" }
+          $expectedBinary = if ($classifier.StartsWith("windows")) { "bin/Release/thrift.exe" } else { "bin/thrift" }
           Write-Host "Archive: $($zip.Name)"
           $files | ForEach-Object { Write-Host " - $_" }
 

--- a/.github/workflows/iotdb-tools-thrift-artifacts.yml
+++ b/.github/workflows/iotdb-tools-thrift-artifacts.yml
@@ -1,0 +1,187 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build IoTDB Tools Thrift Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Optional branch, tag, or commit SHA to build
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iotdb-tools-thrift-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.classifier }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - classifier: linux-x86_64
+            runner: ubuntu-24.04
+            platform: linux
+            maven: ./mvnw
+          - classifier: linux-aarch64
+            runner: ubuntu-24.04-arm
+            platform: linux
+            maven: ./mvnw
+          - classifier: mac-x86_64
+            runner: macos-15-intel
+            platform: macos
+            maven: ./mvnw
+          - classifier: mac-aarch64
+            runner: macos-15
+            platform: macos
+            maven: ./mvnw
+          - classifier: windows-x86_64
+            runner: windows-2022
+            platform: windows
+            maven: .\mvnw.cmd
+          - classifier: windows-aarch64
+            runner: windows-11-arm
+            platform: windows
+            maven: .\mvnw.cmd
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Install Linux build prerequisites
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flex bison g++ make
+
+      - name: Install macOS build prerequisites
+        if: matrix.platform == 'macos'
+        run: brew install bison
+
+      - name: Install Windows build prerequisites
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: choco install winflexbison3 -y --no-progress
+
+      - name: Verify active Maven classifier
+        working-directory: iotdb-tools-thrift
+        shell: pwsh
+        run: |
+          $expected = "${{ matrix.classifier }}"
+          $actual = & "${{ matrix.maven }}" -q help:evaluate "-Dexpression=os.classifier" "-DforceStdout"
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $actual = ($actual | Select-Object -Last 1).Trim()
+          Write-Host "Expected classifier: $expected"
+          Write-Host "Maven classifier: $actual"
+          if ($actual -ne $expected) {
+            throw "Maven activated classifier '$actual', expected '$expected'"
+          }
+
+      - name: Build artifact
+        working-directory: iotdb-tools-thrift
+        shell: pwsh
+        run: |
+          & "${{ matrix.maven }}" clean package -DskipTests
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Verify archive contents
+        working-directory: iotdb-tools-thrift
+        shell: pwsh
+        run: |
+          $classifier = "${{ matrix.classifier }}"
+          $zip = Get-ChildItem -Path target -Filter "*-$classifier.zip" | Select-Object -First 1
+          if (-not $zip) {
+            throw "No zip file found for classifier $classifier"
+          }
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::OpenRead($zip.FullName)
+          try {
+            $files = $archive.Entries | Where-Object { $_.Name } | ForEach-Object { $_.FullName }
+          } finally {
+            $archive.Dispose()
+          }
+
+          $expectedBinary = if ($classifier.StartsWith("windows")) { "bin/thrift.exe" } else { "bin/thrift" }
+          Write-Host "Archive: $($zip.Name)"
+          $files | ForEach-Object { Write-Host " - $_" }
+
+          if ($files.Count -ne 1) {
+            throw "Expected exactly one file in the archive, found $($files.Count)"
+          }
+          if ($files -notcontains $expectedBinary) {
+            throw "Expected archive to contain $expectedBinary"
+          }
+
+      - name: Upload platform artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iotdb-tools-thrift-${{ matrix.classifier }}
+          path: iotdb-tools-thrift/target/*-${{ matrix.classifier }}.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+  bundle:
+    name: Bundle all platform artifacts
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - name: Download platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: iotdb-tools-thrift-*
+          merge-multiple: true
+
+      - name: Verify bundled artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -lah dist
+          test "$(find dist -maxdepth 1 -name '*.zip' | wc -l)" -eq 6
+
+      - name: Upload bundled artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iotdb-tools-thrift-all-platforms
+          path: dist/*.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.github/workflows/iotdb-tools-thrift-artifacts.yml
+++ b/.github/workflows/iotdb-tools-thrift-artifacts.yml
@@ -43,11 +43,11 @@ jobs:
       matrix:
         include:
           - classifier: linux-x86_64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
             platform: linux
             maven: ./mvnw
           - classifier: linux-aarch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
             platform: linux
             maven: ./mvnw
           - classifier: mac-x86_64
@@ -149,6 +149,35 @@ jobs:
             throw "Expected archive to contain $expectedBinary"
           }
 
+          $extractDir = Join-Path $env:RUNNER_TEMP "thrift-$classifier"
+          Remove-Item -Recurse -Force $extractDir -ErrorAction SilentlyContinue
+          Expand-Archive -Path $zip.FullName -DestinationPath $extractDir
+          $binary = Join-Path $extractDir $expectedBinary
+          if (-not (Test-Path $binary)) {
+            throw "Expected binary not found after extraction: $expectedBinary"
+          }
+          if (-not $classifier.StartsWith("windows")) {
+            chmod +x $binary
+          }
+
+          $version = & $binary --version
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $version = ($version | Select-Object -Last 1).Trim()
+          Write-Host "Thrift version output: $version"
+          if ($version -ne "Thrift version 0.23.0") {
+            throw "Unexpected thrift version output: $version"
+          }
+
+          if ($classifier.StartsWith("linux")) {
+            $fileInfo = & file $binary
+            Write-Host "file output: $fileInfo"
+            if ($fileInfo -notmatch "statically linked") {
+              throw "Expected Linux thrift binary to be statically linked"
+            }
+          }
+
       - name: Upload platform artifact
         uses: actions/upload-artifact@v4
         with:
@@ -160,7 +189,7 @@ jobs:
 
   bundle:
     name: Bundle all platform artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Download platform artifacts
@@ -176,6 +205,9 @@ jobs:
           set -euo pipefail
           ls -lah dist
           test "$(find dist -maxdepth 1 -name '*.zip' | wc -l)" -eq 6
+          for classifier in linux-x86_64 linux-aarch64 mac-x86_64 mac-aarch64 windows-x86_64 windows-aarch64; do
+            test "$(find dist -maxdepth 1 -name "*-${classifier}.zip" | wc -l)" -eq 1
+          done
 
       - name: Upload bundled artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/iotdb-tools-thrift-artifacts.yml
+++ b/.github/workflows/iotdb-tools-thrift-artifacts.yml
@@ -26,6 +26,10 @@ on:
         description: Optional branch, tag, or commit SHA to build
         required: false
         type: string
+  pull_request:
+    paths:
+      - .github/workflows/iotdb-tools-thrift-artifacts.yml
+      - iotdb-tools-thrift/**
 
 permissions:
   contents: read
@@ -71,7 +75,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git_ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || github.ref }}
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@
 **/.DS_Store
 derby-tsfile-db
 /iotdb-tools-thrift/target/
+/iotdb-tools-thrift/prebuilt-artifacts/
 /iotdb-tools-thrift/.mvn/wrapper/maven-wrapper.jar

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -49,7 +49,65 @@ Run the following command from this directory:
 The archive is generated under `target/`. Check that it contains `bin/thrift`
 and that the binary reports the expected Apache Thrift version.
 
-## Deploy to Nexus
+## Build Release Artifacts With GitHub Actions
+
+The `Build IoTDB Tools Thrift Artifacts` workflow builds the six platform zip
+artifacts without signing or deploying them. Trigger it manually from GitHub
+Actions, optionally passing a branch, tag, or commit SHA in the `git_ref` input.
+
+The workflow uploads one bundled artifact named
+`iotdb-tools-thrift-all-platforms`. Download and extract that artifact into this
+directory:
+
+    iotdb-tools-thrift/prebuilt-artifacts/
+
+If you use the GitHub CLI, run:
+
+    gh run download <run-id> --name iotdb-tools-thrift-all-platforms --dir prebuilt-artifacts
+
+The directory must contain these files:
+
+- `iotdb-tools-thrift-${project.version}-linux-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-linux-aarch64.zip`
+- `iotdb-tools-thrift-${project.version}-mac-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-mac-aarch64.zip`
+- `iotdb-tools-thrift-${project.version}-windows-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-windows-aarch64.zip`
+
+`${project.version}` is the Maven project version, for example `0.23.0.0`.
+
+Verify the archives before deploying them. Each archive should contain only the
+`bin/thrift` executable, or `bin/thrift.exe` on Windows, and the executable
+should report the expected Apache Thrift version.
+
+## Deploy Prebuilt Artifacts to Nexus
+
+Run the deploy locally from this directory. This signs and deploys the six
+prebuilt platform artifacts from `prebuilt-artifacts/`:
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts
+
+Use `prebuilt.artifacts.dir` if the downloaded artifacts are in another
+directory:
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts -Dprebuilt.artifacts.dir=/path/to/prebuilt-artifacts
+
+This creates a new staging repository in Nexus. After the deploy completes, open
+https://repository.apache.org/#stagingRepositories and verify the uploaded
+artifacts.
+
+If you need to re-run the local deploy into an existing staging repository, pass
+that exact staging repository id:
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts -DstagingRepositoryId=orgapacheiotdb-1234
+
+The `stagingRepositoryId` value must be an existing Nexus staging repository id.
+Do not use a made-up id.
+
+## Deploy by Building on Each Platform
+
+If you do not use the prebuilt artifacts workflow, you can still deploy by
+building on each platform.
 
 Run the first deploy on one platform without `stagingRepositoryId`:
 
@@ -63,10 +121,7 @@ Run the deploy on each remaining platform with that exact staging repository id:
 
     ./mvnw clean deploy -P apache-release -DstagingRepositoryId=orgapacheiotdb-1234
 
-The `stagingRepositoryId` value must be an existing Nexus staging repository id
-created by the first deploy. Do not use a made-up id.
-
-Supported classifiers are selected by the active OS profile:
+Supported classifiers are:
 
 - `linux-x86_64`
 - `linux-aarch64`

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -54,8 +54,8 @@ and that the binary reports the expected Apache Thrift version.
 The `Build IoTDB Tools Thrift Artifacts` workflow builds the six platform zip
 artifacts without signing or deploying them. Trigger it manually from GitHub
 Actions, optionally passing a branch, tag, or commit SHA in the `git_ref` input.
-Linux artifacts are built on Ubuntu 22.04 runners to keep the generated
-executables compatible with older glibc versions.
+The workflow verifies that each generated compiler reports the expected Apache
+Thrift version, and that Linux compilers are statically linked.
 
 The workflow uploads one bundled artifact named
 `iotdb-tools-thrift-all-platforms`. Download and extract that artifact into this

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -35,7 +35,8 @@ Install the following software before building this module:
 - GPG configured for Apache release signing
 - Apache Nexus credentials configured as `apache.releases.https` in Maven `settings.xml`
 
-Linux static builds may also need static zlib and OpenSSL development packages.
+Linux profiles build the `thrift` executable with `-static`, so the build host
+needs the static runtime libraries required by its C/C++ toolchain.
 
 Use `mvnw.cmd` instead of `./mvnw` on Windows.
 

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -54,6 +54,8 @@ and that the binary reports the expected Apache Thrift version.
 The `Build IoTDB Tools Thrift Artifacts` workflow builds the six platform zip
 artifacts without signing or deploying them. Trigger it manually from GitHub
 Actions, optionally passing a branch, tag, or commit SHA in the `git_ref` input.
+Linux artifacts are built on Ubuntu 22.04 runners to keep the generated
+executables compatible with older glibc versions.
 
 The workflow uploads one bundled artifact named
 `iotdb-tools-thrift-all-platforms`. Download and extract that artifact into this

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -21,31 +21,58 @@
 
 # Releasing the IoTDB Tools: Thrift
 
-    ./mvnw clean deploy -P apache-release
-
-On the first run, comment out the "stagingRepositoryId" property. 
-This will make the build deploy the rc in a new staging repository in nexus.
-
-As soon as the build is finished, go to https://repository.apache.org/#stagingRepositories and take the new repository id from there and comment in the property again and update the value to that of the staging repository and commit that.
-
-This will make it easy for the other platform deployment. 
-
-Then checkout the repo on the other platforms and run the following on each of the other platforms:
-
-    ./mvnw clean deploy -P apache-release
-
-> Note: For some reason you will see errors a the end when deploying the other artifacts, however in all cases I did see the artifacts deployed correctly.
-
-Once this has been run on each of the supported platforms, go back to Nexus and close the staging repository.
+This module publishes platform-specific Apache Thrift compiler archives used by
+IoTDB builds. The archives contain the `thrift` executable only.
 
 ## Prerequisites
 
-The following software needs to be installed in order to build the thrift module:
+Install the following software before building this module:
 
-- Java
+- JDK
 - Flex
 - Bison
-- Boost
-- Ssl
+- A C/C++ build toolchain supported by CMake
+- GPG configured for Apache release signing
+- Apache Nexus credentials configured as `apache.releases.https` in Maven `settings.xml`
 
-Please look in the IoTDB documentation for information on how to install them on your particular OS.
+Linux static builds may also need static zlib and OpenSSL development packages.
+
+Use `mvnw.cmd` instead of `./mvnw` on Windows.
+
+## Build Locally
+
+Run the following command from this directory:
+
+    ./mvnw clean package -DskipTests
+
+The archive is generated under `target/`. Check that it contains `bin/thrift`
+and that the binary reports the expected Apache Thrift version.
+
+## Deploy to Nexus
+
+Run the first deploy on one platform without `stagingRepositoryId`:
+
+    ./mvnw clean deploy -P apache-release
+
+This creates a new staging repository in Nexus. After the deploy completes, open
+https://repository.apache.org/#stagingRepositories and copy the generated staging
+repository id, for example `orgapacheiotdb-1234`.
+
+Run the deploy on each remaining platform with that exact staging repository id:
+
+    ./mvnw clean deploy -P apache-release -DstagingRepositoryId=orgapacheiotdb-1234
+
+The `stagingRepositoryId` value must be an existing Nexus staging repository id
+created by the first deploy. Do not use a made-up id.
+
+Supported classifiers are selected by the active OS profile:
+
+- `linux-x86_64`
+- `linux-aarch64`
+- `mac-x86_64`
+- `mac-aarch64`
+- `windows-x86_64`
+- `windows-aarch64`
+
+After all platform archives have been deployed, verify the staging repository in
+Nexus, close it, and continue with the Apache release vote and release process.

--- a/iotdb-tools-thrift/README.md
+++ b/iotdb-tools-thrift/README.md
@@ -79,8 +79,8 @@ The directory must contain these files:
 `${project.version}` is the Maven project version, for example `0.23.0.0`.
 
 Verify the archives before deploying them. Each archive should contain only the
-`bin/thrift` executable, or `bin/thrift.exe` on Windows, and the executable
-should report the expected Apache Thrift version.
+`bin/thrift` executable, or `bin/Release/thrift.exe` on Windows, and the
+executable should report the expected Apache Thrift version.
 
 ## Deploy Prebuilt Artifacts to Nexus
 

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -54,6 +54,8 @@ Windows 上请使用 `mvnw.cmd` 替代 `./mvnw`。
 `Build IoTDB Tools Thrift Artifacts` workflow 会构建六个平台的 zip artifacts，
 但不会签名，也不会 deploy 到 Nexus。请在 GitHub Actions 页面手动触发该
 workflow，可以通过 `git_ref` 输入指定要构建的分支、tag 或 commit SHA。
+Linux artifacts 会固定使用 Ubuntu 22.04 runner 构建，以便生成的可执行文件
+兼容更老的 glibc 版本。
 
 workflow 会上传一个名为 `iotdb-tools-thrift-all-platforms` 的汇总 artifact。
 下载并解压到当前模块的以下目录：

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -1,0 +1,78 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# 发布 IoTDB Tools: Thrift
+
+本模块用于发布 IoTDB 构建过程中使用的、按平台区分的 Apache Thrift
+compiler 压缩包。压缩包中只包含 `thrift` 可执行文件。
+
+## 环境准备
+
+构建本模块前需要安装以下软件：
+
+- JDK
+- Flex
+- Bison
+- CMake 支持的 C/C++ 构建工具链
+- 已配置好 Apache 发布签名的 GPG
+- 在 Maven `settings.xml` 中配置好 server id 为 `apache.releases.https` 的 Apache Nexus 凭据
+
+Linux 静态构建可能还需要安装 zlib 和 OpenSSL 的静态开发包。
+
+Windows 上请使用 `mvnw.cmd` 替代 `./mvnw`。
+
+## 本地构建
+
+在当前目录执行：
+
+    ./mvnw clean package -DskipTests
+
+构建产物会生成到 `target/` 目录下。请确认压缩包中包含 `bin/thrift`，并确认该
+二进制文件输出的 Apache Thrift 版本符合预期。
+
+## 发布到 Nexus
+
+先在一个平台上执行第一次 deploy，不要传入 `stagingRepositoryId`：
+
+    ./mvnw clean deploy -P apache-release
+
+这一步会在 Nexus 中创建新的 staging repository。deploy 完成后，打开
+https://repository.apache.org/#stagingRepositories，复制新创建出来的 staging
+repository id，例如 `orgapacheiotdb-1234`。
+
+然后在其余平台上执行 deploy，并传入第一次创建出来的 staging repository id：
+
+    ./mvnw clean deploy -P apache-release -DstagingRepositoryId=orgapacheiotdb-1234
+
+`stagingRepositoryId` 必须是第一次 deploy 后 Nexus 里真实存在的 staging
+repository id，不能随便填写一个不存在的 id。
+
+支持的平台 classifier 由当前操作系统激活的 Maven profile 决定：
+
+- `linux-x86_64`
+- `linux-aarch64`
+- `mac-x86_64`
+- `mac-aarch64`
+- `windows-x86_64`
+- `windows-aarch64`
+
+所有平台压缩包都 deploy 完成后，在 Nexus 中检查 staging repository，确认无误后
+close，然后继续 Apache release vote 和 release 流程。

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -35,7 +35,8 @@ compiler 压缩包。压缩包中只包含 `thrift` 可执行文件。
 - 已配置好 Apache 发布签名的 GPG
 - 在 Maven `settings.xml` 中配置好 server id 为 `apache.releases.https` 的 Apache Nexus 凭据
 
-Linux 静态构建可能还需要安装 zlib 和 OpenSSL 的静态开发包。
+Linux profile 会用 `-static` 链接 `thrift` 可执行文件，因此构建机器需要具备
+当前 C/C++ 工具链静态链接所需的运行时库。
 
 Windows 上请使用 `mvnw.cmd` 替代 `./mvnw`。
 

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -54,8 +54,8 @@ Windows 上请使用 `mvnw.cmd` 替代 `./mvnw`。
 `Build IoTDB Tools Thrift Artifacts` workflow 会构建六个平台的 zip artifacts，
 但不会签名，也不会 deploy 到 Nexus。请在 GitHub Actions 页面手动触发该
 workflow，可以通过 `git_ref` 输入指定要构建的分支、tag 或 commit SHA。
-Linux artifacts 会固定使用 Ubuntu 22.04 runner 构建，以便生成的可执行文件
-兼容更老的 glibc 版本。
+workflow 会验证每个平台生成的 compiler 是否输出预期的 Apache Thrift 版本，
+并确认 Linux compiler 是静态链接的。
 
 workflow 会上传一个名为 `iotdb-tools-thrift-all-platforms` 的汇总 artifact。
 下载并解压到当前模块的以下目录：

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -78,8 +78,8 @@ workflow 会上传一个名为 `iotdb-tools-thrift-all-platforms` 的汇总 arti
 `${project.version}` 是 Maven 项目版本，例如 `0.23.0.0`。
 
 deploy 前请先检查这些压缩包。每个压缩包应当只包含 `bin/thrift` 可执行文件，
-Windows 平台为 `bin/thrift.exe`，并且该可执行文件输出的 Apache Thrift 版本
-符合预期。
+Windows 平台为 `bin/Release/thrift.exe`，并且该可执行文件输出的 Apache
+Thrift 版本符合预期。
 
 ## 将预构建 artifacts 发布到 Nexus
 

--- a/iotdb-tools-thrift/README_zh.md
+++ b/iotdb-tools-thrift/README_zh.md
@@ -49,7 +49,62 @@ Windows 上请使用 `mvnw.cmd` 替代 `./mvnw`。
 构建产物会生成到 `target/` 目录下。请确认压缩包中包含 `bin/thrift`，并确认该
 二进制文件输出的 Apache Thrift 版本符合预期。
 
-## 发布到 Nexus
+## 使用 GitHub Actions 构建发布 artifacts
+
+`Build IoTDB Tools Thrift Artifacts` workflow 会构建六个平台的 zip artifacts，
+但不会签名，也不会 deploy 到 Nexus。请在 GitHub Actions 页面手动触发该
+workflow，可以通过 `git_ref` 输入指定要构建的分支、tag 或 commit SHA。
+
+workflow 会上传一个名为 `iotdb-tools-thrift-all-platforms` 的汇总 artifact。
+下载并解压到当前模块的以下目录：
+
+    iotdb-tools-thrift/prebuilt-artifacts/
+
+如果使用 GitHub CLI，可以执行：
+
+    gh run download <run-id> --name iotdb-tools-thrift-all-platforms --dir prebuilt-artifacts
+
+该目录中必须包含以下文件：
+
+- `iotdb-tools-thrift-${project.version}-linux-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-linux-aarch64.zip`
+- `iotdb-tools-thrift-${project.version}-mac-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-mac-aarch64.zip`
+- `iotdb-tools-thrift-${project.version}-windows-x86_64.zip`
+- `iotdb-tools-thrift-${project.version}-windows-aarch64.zip`
+
+`${project.version}` 是 Maven 项目版本，例如 `0.23.0.0`。
+
+deploy 前请先检查这些压缩包。每个压缩包应当只包含 `bin/thrift` 可执行文件，
+Windows 平台为 `bin/thrift.exe`，并且该可执行文件输出的 Apache Thrift 版本
+符合预期。
+
+## 将预构建 artifacts 发布到 Nexus
+
+在当前目录本地执行 deploy。该命令会对 `prebuilt-artifacts/` 下的六个平台
+artifacts 签名并 deploy：
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts
+
+如果下载目录不是默认的 `prebuilt-artifacts/`，可以通过
+`prebuilt.artifacts.dir` 指定：
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts -Dprebuilt.artifacts.dir=/path/to/prebuilt-artifacts
+
+这一步会在 Nexus 中创建新的 staging repository。deploy 完成后，打开
+https://repository.apache.org/#stagingRepositories，检查上传的 artifacts。
+
+如果需要重新 deploy 到已有 staging repository，请传入真实存在的 staging
+repository id：
+
+    ./mvnw clean deploy -P apache-release,prebuilt-artifacts -DstagingRepositoryId=orgapacheiotdb-1234
+
+`stagingRepositoryId` 必须是 Nexus 里真实存在的 staging repository id，不能
+随便填写一个不存在的 id。
+
+## 在每个平台本地构建并发布
+
+如果不使用预构建 artifacts workflow，也可以继续按平台分别构建并 deploy。
 
 先在一个平台上执行第一次 deploy，不要传入 `stagingRepositoryId`：
 
@@ -63,10 +118,7 @@ repository id，例如 `orgapacheiotdb-1234`。
 
     ./mvnw clean deploy -P apache-release -DstagingRepositoryId=orgapacheiotdb-1234
 
-`stagingRepositoryId` 必须是第一次 deploy 后 Nexus 里真实存在的 staging
-repository id，不能随便填写一个不存在的 id。
-
-支持的平台 classifier 由当前操作系统激活的 Maven profile 决定：
+支持的平台 classifier 包括：
 
 - `linux-x86_64`
 - `linux-aarch64`

--- a/iotdb-tools-thrift/pom.xml
+++ b/iotdb-tools-thrift/pom.xml
@@ -33,18 +33,14 @@
         contains nothing else as the compiled thrift binary without any modification.
         The fourth segment allows us to re-deploy, if we need to change the config.
     -->
-    <version>0.20.0.0</version>
+    <version>0.23.0.0</version>
     <packaging>pom</packaging>
 
     <name>IoTDB-Tools: Thrift</name>
     <description>Local build of the Apache Thrift compiler.</description>
 
     <properties>
-        <thrift.version>0.20.0</thrift.version>
-        <thrift.with.cpp>ON</thrift.with.cpp>
-        <thrift.with.go>ON</thrift.with.go>
-        <thrift.with.python>ON</thrift.with.python>
-        <thrift.with.rust>ON</thrift.with.rust>
+        <thrift.version>0.23.0</thrift.version>
         <cmake.generator>Unix Makefiles</cmake.generator>
         <cmake.build.type>Release</cmake.build.type>
     </properties>
@@ -96,48 +92,39 @@
                             <options>
                                 <!-- Disable testing for now -->
                                 <option>-DBUILD_TESTING=OFF</option>
+                                <!-- The release artifact only packages the compiler binary -->
+                                <option>-DBUILD_LIBRARIES=OFF</option>
+                                <option>-DBUILD_TUTORIALS=OFF</option>
                                 <!-- Enable and disable the building of code generators for different languages -->
-                                <option>-DTHRIFT_COMPILER_AS3=OFF</option>
                                 <option>-DTHRIFT_COMPILER_C_GLIB=OFF</option>
                                 <option>-DTHRIFT_COMPILER_CL=OFF</option>
-                                <option>-DTHRIFT_COMPILER_CPP=${thrift.with.cpp}</option>
+                                <option>-DTHRIFT_COMPILER_CPP=OFF</option>
                                 <option>-DTHRIFT_COMPILER_D=OFF</option>
                                 <option>-DTHRIFT_COMPILER_DART=OFF</option>
                                 <option>-DTHRIFT_COMPILER_DELPHI=OFF</option>
                                 <option>-DTHRIFT_COMPILER_ERL=OFF</option>
-                                <option>-DTHRIFT_COMPILER_GO=${thrift.with.go}</option>
+                                <option>-DTHRIFT_COMPILER_GO=ON</option>
                                 <option>-DTHRIFT_COMPILER_GV=OFF</option>
                                 <option>-DTHRIFT_COMPILER_HAXE=OFF</option>
-                                <option>-DTHRIFT_COMPILER_HS=OFF</option>
                                 <option>-DTHRIFT_COMPILER_HTML=OFF</option>
                                 <option>-DTHRIFT_COMPILER_JAVA=ON</option>
-                                <option>-DTHRIFT_COMPILER_JAVAME=ON</option>
+                                <option>-DTHRIFT_COMPILER_JAVAME=OFF</option>
+                                <option>-DTHRIFT_COMPILER_JS=ON</option>
                                 <option>-DTHRIFT_COMPILER_JSON=OFF</option>
+                                <option>-DTHRIFT_COMPILER_KOTLIN=OFF</option>
                                 <option>-DTHRIFT_COMPILER_LUA=OFF</option>
+                                <option>-DTHRIFT_COMPILER_MARKDOWN=OFF</option>
                                 <option>-DTHRIFT_COMPILER_NETSTD=ON</option>
                                 <option>-DTHRIFT_COMPILER_OCAML=OFF</option>
                                 <option>-DTHRIFT_COMPILER_PERL=OFF</option>
                                 <option>-DTHRIFT_COMPILER_PHP=OFF</option>
-                                <option>-DTHRIFT_COMPILER_PY=${thrift.with.python}</option>
+                                <option>-DTHRIFT_COMPILER_PY=ON</option>
                                 <option>-DTHRIFT_COMPILER_RB=OFF</option>
-                                <option>-DTHRIFT_COMPILER_RS=${thrift.with.rust}</option>
+                                <option>-DTHRIFT_COMPILER_RS=ON</option>
                                 <option>-DTHRIFT_COMPILER_ST=OFF</option>
                                 <option>-DTHRIFT_COMPILER_SWIFT=OFF</option>
                                 <option>-DTHRIFT_COMPILER_XML=OFF</option>
                                 <option>-DTHRIFT_COMPILER_XSD=OFF</option>
-                                <!-- Enable and disable the building of libs for different languages -->
-                                <option>-DBUILD_C_GLIB=OFF</option>
-                                <option>-DBUILD_CPP=${thrift.with.cpp}</option>
-                                <!-- Don't build Java, as the libs are available via Maven -->
-                                <option>-DBUILD_JAVA=OFF</option>
-                                <option>-DBUILD_NODEJS=OFF</option>
-                                <option>-DBUILD_PYTHON=${thrift.with.python}</option>
-                                <option>-DBUILD_JAVASCRIPT=OFF</option>
-                                <option>-DBUILD_HASKELL=OFF</option>
-                                <option>-DWITH_SHARED_LIB=OFF</option>
-                                <!-- Generate libthrift.a to compile IoTDB Session -->
-                                <option>-DWITH_STATIC_LIB=ON</option>
-                                <option>-DCMAKE_POSITION_INDEPENDENT_CODE=ON</option>
                             </options>
                         </configuration>
                     </execution>
@@ -159,8 +146,7 @@
 
             <!--
                 Bundle up the needed parts into an archive for this architecture
-                The bundle contains the Thrift executable, the shared libraries and the header-files,
-                which are all needed to build the client
+                The bundle contains the Thrift executable.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -208,6 +194,11 @@
 
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>1.7.1</version>
+                </plugin>
                 <plugin>
                     <groupId>com.googlecode.cmake-maven-project</groupId>
                     <artifactId>cmake-maven-plugin</artifactId>

--- a/iotdb-tools-thrift/pom.xml
+++ b/iotdb-tools-thrift/pom.xml
@@ -222,7 +222,6 @@
                         <serverId>apache.releases.https</serverId>
                         <nexusUrl>https://repository.apache.org</nexusUrl>
                         <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                        <stagingRepositoryId>orgapacheiotdb-1158</stagingRepositoryId>
                     </configuration>
                 </plugin>
             </plugins>
@@ -230,6 +229,28 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>reuse-staging-repository</id>
+            <activation>
+                <property>
+                    <name>stagingRepositoryId</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.sonatype.plugins</groupId>
+                            <artifactId>nexus-staging-maven-plugin</artifactId>
+                            <configuration>
+                                <stagingRepositoryId>${stagingRepositoryId}</stagingRepositoryId>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
         <profile>
             <id>.os-unix</id>
             <activation>

--- a/iotdb-tools-thrift/pom.xml
+++ b/iotdb-tools-thrift/pom.xml
@@ -43,6 +43,7 @@
         <thrift.version>0.23.0</thrift.version>
         <cmake.generator>Unix Makefiles</cmake.generator>
         <cmake.build.type>Release</cmake.build.type>
+        <prebuilt.artifacts.dir>${project.basedir}/prebuilt-artifacts</prebuilt.artifacts.dir>
     </properties>
 
     <repositories>
@@ -153,6 +154,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>binary-assembly</id>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -203,6 +205,11 @@
                     <groupId>com.googlecode.cmake-maven-project</groupId>
                     <artifactId>cmake-maven-plugin</artifactId>
                     <version>3.29.3-b2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
@@ -445,6 +452,95 @@
                 <!-- We're using Mingw everywhere else, but it seems boost is not supported for that -->
                 <cmake.generator>Visual Studio 17 2022</cmake.generator>
             </properties>
+        </profile>
+
+        <profile>
+            <id>prebuilt-artifacts</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>get-thrift</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.googlecode.cmake-maven-project</groupId>
+                        <artifactId>cmake-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cmake-generate</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>cmake-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>binary-assembly</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-prebuilt-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-linux-x86_64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>linux-x86_64</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-linux-aarch64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>linux-aarch64</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-mac-x86_64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>mac-x86_64</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-mac-aarch64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>mac-aarch64</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-windows-x86_64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>windows-x86_64</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${prebuilt.artifacts.dir}/${project.artifactId}-${project.version}-windows-aarch64.zip</file>
+                                            <type>zip</type>
+                                            <classifier>windows-aarch64</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/iotdb-tools-thrift/src/main/assembly/thrift.xml
+++ b/iotdb-tools-thrift/src/main/assembly/thrift.xml
@@ -35,31 +35,5 @@
             </includes>
             <outputDirectory>bin</outputDirectory>
         </fileSet>
-        <!-- Include the shared-libraries -->
-        <fileSet>
-            <directory>${project.build.directory}/build</directory>
-            <includes>
-                <include>lib/*.a</include>
-                <include>lib/Release/*.lib</include>
-                <include>lib/Debug/*.lib</include>
-            </includes>
-            <outputDirectory>/</outputDirectory>
-        </fileSet>
-        <!-- Include the header-files -->
-        <fileSet>
-            <directory>${project.build.directory}/thrift-${thrift.version}/lib/cpp/src</directory>
-            <includes>
-                <include>**</include>
-            </includes>
-            <outputDirectory>include</outputDirectory>
-        </fileSet>
-        <!-- Include the config.h -->
-        <fileSet>
-            <directory>${project.build.directory}/build/thrift</directory>
-            <includes>
-                <include>config.h</include>
-            </includes>
-            <outputDirectory>include/thrift</outputDirectory>
-        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
## Summary

- Release `iotdb-tools-thrift` as version `0.23.0.0` based on Apache Thrift `0.23.0`.
- Build a compiler-only artifact by disabling Thrift runtime library and tutorial builds.
- Keep only the needed compiler generators enabled, including Java, JavaScript/Node.js, Go, Python, Rust, and .NET Standard, while disabling C++ and Java ME generators.
- Package only the `bin/thrift` executable in the platform zip.
- Make the Nexus `stagingRepositoryId` configurable by Maven property and document the multi-platform release flow in English and Chinese.
- Add a GitHub Actions workflow to build all six platform zips and bundle them as one downloadable artifact.
- Add a `prebuilt-artifacts` Maven profile so the release manager can download CI-built zips locally, sign them, and deploy all classifiers to Nexus from one machine.

## Validation

- `mvn clean package -DskipTests`
- `mvn clean package -P prebuilt-artifacts -Dprebuilt.artifacts.dir=/tmp/iotdb-tools-thrift-prebuilt-test -DskipTests`
- `mvn package -P apache-release,prebuilt-artifacts -Dprebuilt.artifacts.dir=/tmp/iotdb-tools-thrift-prebuilt-test -DskipTests -Dgpg.skip=true`
- `mvn install -P apache-release,prebuilt-artifacts -Dprebuilt.artifacts.dir=/tmp/iotdb-tools-thrift-prebuilt-test -DskipTests -Dgpg.skip=true`
- Verified the generated zip contains only `bin/thrift`.
- Verified the generated compiler reports `Thrift version 0.23.0`.
- Verified the effective POM injects `stagingRepositoryId` only when `-DstagingRepositoryId=...` is provided.
- Parsed the new GitHub Actions and Dependabot YAML files locally.
- GitHub Actions run passed for all six platform artifacts and the bundled artifact: https://github.com/apache/iotdb-bin-resources/actions/runs/27522562815